### PR TITLE
Remove extraneous single quote

### DIFF
--- a/src/VivaException.php
+++ b/src/VivaException.php
@@ -8,6 +8,6 @@ class VivaException extends Exception
 {
     public function __construct($message, $code)
     {
-        parent::__construct("Error {$code}': {$message}", $code);
+        parent::__construct("Error {$code}: {$message}", $code);
     }
 }


### PR DESCRIPTION
I've noticed this single quote for a while now but made the assumption it was coming back from the API.

If save to do so, this PR removes it.