### PR TITLE
capturePreAuthTransaction API is using POST instead of GET method

### DIFF
--- a/src/NativeCheckout.php
+++ b/src/NativeCheckout.php
@@ -139,7 +139,7 @@ class NativeCheckout
     ): string {
         $parameters = ['amount' => $amount];
 
-        $response = $this->client->get(
+        $response = $this->client->post(
             $this->client->getApiUrl()->withPath(
                 "/nativecheckout/v2/transactions/{$preauthTransactionId}"
             ),


### PR DESCRIPTION
This method had wrong method type and issuing 405 Method not allowed error.