### PR TITLE
make $bankId optional on Responses/Transaction.php

### DIFF
--- a/src/Responses/Transaction.php
+++ b/src/Responses/Transaction.php
@@ -10,7 +10,7 @@ class Transaction extends Data
 {
     public function __construct(
         public readonly string $email,
-        public readonly string $bankId,
+        public readonly ?string $bankId,
         public readonly float $amount,
         public readonly bool $switching,
         public readonly string $orderCode,


### PR DESCRIPTION
It can be null in some cases.