### PR TITLE
Make Email field nullable in TransactionPaymentCreated

### DIFF
--- a/src/Events/TransactionPaymentCreated.php
+++ b/src/Events/TransactionPaymentCreated.php
@@ -11,7 +11,7 @@ class TransactionPaymentCreated extends Data
 {
     public function __construct(
         public readonly bool $Moto,
-        public readonly string $Email,
+        public readonly ?string $Email,
         public readonly ?string $Phone,
         public readonly string $BankId,
         public readonly bool $Systemic,


### PR DESCRIPTION
I received some payloads from VivaWallet that had this field set to null.